### PR TITLE
more portable shebang

### DIFF
--- a/latex2png
+++ b/latex2png
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # latex2png
 #


### PR DESCRIPTION
Some systems don't have bash in /bin, for example  NixOS, FreeBSD and Open BSD. I think this change will make your software more portable. By the way, thank you for making latex2png available!